### PR TITLE
adding gauge metric for filterCache.hitratio

### DIFF
--- a/solr_collectd.py
+++ b/solr_collectd.py
@@ -32,6 +32,8 @@ CORE_METRICS = {
         Metric('solr.document_cache_cumulative_hitratio', 'gauge'),
     'CACHE.searcher.fieldValueCache.cumulative_hitratio':
         Metric('solr.field_value_cache_cumulative_hitratio', 'gauge'),
+    'CACHE.searcher.filterCache.cumulative_hitratio':
+        Metric('solr.filter_cache_cumulative_hitratio', 'gauge'),
     'CACHE.searcher.queryResultCache.cumulative_hitratio':
         Metric('solr.query_result_cache_cumulative_hitratio', 'gauge'),
     'QUERY./select.requestTimes.mean_ms':


### PR DESCRIPTION
next to the document, query result and field value cache the filter
cache is quite important as well and this commit will expose it as
a core metric