### PR TITLE
avoid an exception when API error out and response is None

### DIFF
--- a/solr_collectd.py
+++ b/solr_collectd.py
@@ -317,6 +317,8 @@ def get_leader_node(data):
     url = "{0}/admin/collections?action=OVERSEERSTATUS&wt=json".format(data["base_url"])
     response = _api_call(url, data["opener"])
 
+    if response is None:
+        return None
     return response["leader"]
 
 


### PR DESCRIPTION
This PR addresses the below exception

```
time="2021-04-22T07:36:16Z" level=error msg="Error making API call (HTTP Error 500: Server Error) http://127.0.0.1:8983/solr/admin/collections?action=OVERSEERSTATUS&wt=json" createdTime=1.6190769768283772e+09 lineno=288 logger=root   monitorID=12 monitorType=collectd/solr runnerPID=18370 sourcePath=/usr/lib/signalfx-agent/collectd-python/solr/solr_collectd.py
time="2021-04-22T07:36:16Z" level=error msg="Traceback (most recent call last):\n\n  File \"/usr/lib/signalfx-agent/lib/python3.8/site-packages/sfxrunner/scheduler/simple.py\", line 50, in _call_on_interval\n    func()\n\n  File \"/usr/lib/signalfx-agent/collectd-python/solr/solr_collectd.py\", line 200, in read_metrics\n    if data[\"member_id\"] + \"_solr\" == get_leader_node(data):\n\n  File \"/usr/lib/signalfx-agent/collectd-python/solr/solr_collectd.py\", line 320, in get_leader_node\n    return response[\"leader\"]\n\nTypeError: 'NoneType' object is not subscriptable\n" createdTime=1.6190769768287094e+09 lineno=56 logger=root monitorID=12 monitorType=collectd/solr runnerPID=18370       sourcePath=/usr/lib/signalfx-agent/lib/python3.8/site-packages/sfxrunner/logs.py
```
Signed-off-by: Dani Louca <dlouca@splunk.com>